### PR TITLE
add project, bucket, object parameters to the command line

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,13 +23,19 @@ import (
 )
 
 var (
-	hostname string
-	region   string
-	httpAddr string
+	hostname   string
+	region     string
+	httpAddr   string
+	projectID  string
+	bucketName string
+	objectName string
 )
 
 func main() {
 	flag.StringVar(&httpAddr, "http", "127.0.0.1:80", "HTTP service address")
+	flag.StringVar(&projectID, "project", "hightowerlabs", "Project ID")
+	flag.StringVar(&bucketName, "bucket", "hello-universe", "Bucket name")
+	flag.StringVar(&objectName, "object", "hello-universe", "Object Name")
 	flag.Parse()
 
 	var err error
@@ -46,9 +52,9 @@ func main() {
 	var dm *kargo.DeploymentManager
 	if kargo.EnableKubernetes {
 		link, err := kargo.Upload(kargo.UploadConfig{
-			ProjectID:  "hightowerlabs",
-			BucketName: "hello-universe",
-			ObjectName: "hello-universe",
+			ProjectID:  projectID,
+			BucketName: bucketName,
+			ObjectName: objectName,
 		})
 
 		if err != nil {


### PR DESCRIPTION
@kelseyhightower 

This Pull Request adds the parameters to the command line, project, bucket and object. 

It was helpful for me to test hello-universe in my GCP account, it may be helpful for other Gophers:

```
[marcosvm@olive] ~/go/src/github.com/marcosvm/hello-universe (marcosvm/few_parameters)
➜ hello-universe -kubernetes -replicas 3  -cpu-limit 200m -memory-limit 500M -project vmlabs-173703 -bucket vmlabs-hello-universe
Starting hello-universe...
Building hello-universe binary...
Created: /var/folders/sv/85b4t3s94jn4s9llrv5p17_w0000gn/T/930545350/hello-universe
Object vmlabs-hello-universe/b790b742a4807b1655ebd118a9c987a7dbf6b7cf6f5b699828f41aa0e52e4dc6/hello-universe already exists, skipping upload.
Creating hello-universe ReplicaSet...
Starting hello-universe...
Starting hello-universe...
Starting hello-universe...
```