### PR TITLE
[WIP] Demo some K8s rules.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -33,6 +33,7 @@ docker_build(
     base = "@base//image",
     files = [":hello-universe"],
     entrypoint = ["/hello-universe"],
+    visibility = ["//visibility:public"],
 )
 
 # I publish the docker image to the specified registry,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,8 +69,8 @@ go_repository(
 
 git_repository(
     name = "io_bazel_rules_docker",
-    remote = "https://github.com/bazelbuild/rules_docker.git",
-    commit = "79aa5de0eb7348876316c537f7cec26bae02cfab",
+    remote = "https://github.com/mattmoor/rules_docker.git",
+    commit = "5ee8f1b66309d6c59762900cf0b8b1b88224ecaf",
 )
 
 load(
@@ -86,3 +86,15 @@ docker_pull(
     repository = "distroless/base",
     digest = "sha256:06fcd3edcfeefe13b82fa8bdb9e3f4fa3bf4c7e8fe997bee0230e392f77d0e04",
 )
+
+git_repository(
+    name = "io_bazel_rules_k8s",
+    remote = "https://github.com/mattmoor/rules_k8s.git",
+    commit = "a3e68dae77514bb96347bfd002560639c10f547e",
+)
+
+load(
+  "@io_bazel_rules_k8s//k8s:k8s.bzl",
+  "k8s_repositories",
+)
+k8s_repositories()

--- a/deployments/BUILD
+++ b/deployments/BUILD
@@ -1,0 +1,25 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+  "@io_bazel_rules_k8s//k8s:k8s.bzl",
+  "k8s_deploy",
+)
+
+k8s_deploy(
+  name = "dev",
+  template = ":hello-universe.yaml.tpl",
+  substitutions = {
+      "environment": "{BUILD_USER}",
+  },
+  images = {
+    "gcr.io/convoy-adapter/hello-universe:{BUILD_USER}": "//:image"
+  },
+)
+
+k8s_deploy(
+  name = "prod",
+  template = ":hello-universe.yaml.tpl",
+  substitutions = {
+      "environment": "1.0.0",
+  },
+)

--- a/deployments/hello-universe.yaml.tpl
+++ b/deployments/hello-universe.yaml.tpl
@@ -1,0 +1,21 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  # Unique key of the Deployment instance
+  name: hello-universe-{environment}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        # Apply this label to pods and default
+        # the Deployment label selector to this value
+        app: hello-universe-{environment}
+    spec:
+      containers:
+      - name: hello-universe
+        image: gcr.io/hightowerlabs/hello-universe:{environment}
+        args:
+        - "-http=0.0.0.0:80"
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
@kelseyhightower If you liked the last one, you might like this one.  This is still very much a prototype (my July 4th hack), but it allows you to rebuild/repush/redeploy to a namespaced environment with a single command:
```shell
  bazel run deployments:dev
```

For me, I can edit and redeploy this to Container Engine in ~6 seconds.

I have yet to try `ibazel` myself, but in principle, you should be able to use the changes here with [`ibazel`](https://github.com/bazelbuild/bazel-watcher) to run:
```shell
  ibazel run deployments:dev
```

... at which point live edits to your Go should be redeployed in seconds.

Still pretty rough (and not schema driven), but I'd love to hear your thoughts.